### PR TITLE
Handle year abbreviations (e.g. '16 for 2016).

### DIFF
--- a/replacements.js
+++ b/replacements.js
@@ -113,7 +113,8 @@ var replacements = [
     { searchFor: /^'ee/gm, replaceWith: "’ee"},   //  (h)e at line beginning (Conrad 'Narcissus')
     { searchFor: /voy'ge/g, replaceWith: "voy’ge"},   //  voy(a)ge (Conrad 'Narcissus')
     { searchFor: /(:|,) '_(\w)/g, replaceWith: "$1 ‘_$2"},   //  italic inside single quote, markdown (Youth)
-    { searchFor: / '<i>/g, replaceWith: " ‘<i>"}   //  italic inside single quote, html (Heart of Darkness)
+    { searchFor: / '<i>/g, replaceWith: " ‘<i>"},   //  italic inside single quote, html (Heart of Darkness)
+    { searchFor: /(\s)'(\d+)/g, replaceWith: "$1’$2"}   //  Abbreviated year: e.g. '6 in the author's note to (Conrad 'Nostromo')
 ];
 //
 module.exports = replacements;


### PR DESCRIPTION
I have tested this on three texts: Conrad's 'Nostromo' (which prompted the change), Joyce's 'Ulysses' and Melville's 'Moby Dick'. For the Conrad book, there is one line that differs: the one that prompted the change to the program:

"As a matter of fact in 1875 or '6, when very young, in the West Indies"

For the other two books, the output is the same both before and after the change.
